### PR TITLE
Update framework.php > correct timezone setting

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -12,7 +12,7 @@ $registry->set('config', $config);
 $log = new Log($config->get('error_filename'));
 $registry->set('log', $log);
 
-date_default_timezone_set($config->get('date_timezone'));
+date_default_timezone_set($config->get('config_timezone'));
 
 set_error_handler(function($code, $message, $file, $line) use($log, $config) {
 	// error suppressed with @


### PR DESCRIPTION
Get correct config value, instead **date_timezone** which is wrong (that's why the error log - and all other functions using the log library) are displaying wrong date stamps ..